### PR TITLE
Normalise collection name

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -46,7 +46,7 @@
 		<meta property="term" refines="#subject-5">Unknown</meta>
 		<meta property="se:subject">Childrens</meta>
 		<meta property="se:subject">Fantasy</meta>
-		<meta id="collection-1" property="belongs-to-collection">Psammead trilogy</meta>
+		<meta id="collection-1" property="belongs-to-collection">Psammead Trilogy</meta>
 		<meta property="collection-type" refines="#collection-1">set</meta>
 		<meta property="group-position" refines="#collection-1">2</meta>
 		<dc:description id="description">Five children once again encounter an ancient, magical creature and go on adventures around the world with its magic carpet.</dc:description>


### PR DESCRIPTION
Collection name isn’t quite identical between books and the SE website has some trouble numbering them.